### PR TITLE
Ensure the table is filtered if the hash is present on page load

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,6 +41,7 @@ $(function() {
         $input = $(':input[type=text]').focus();
         if (window.location.hash.length > 1) {
             $input.val(window.location.hash.slice(1));
+            $table.fnFilter($input.val());
         }
         $input.keyup(function(e) {
             if (e.keyCode === 27) {


### PR DESCRIPTION
If I currently go to, eg, http://eirikb.github.com/nipster/#ssh, the `ssh` term is loaded into the text input, but the table is not filtered.

This pull request ensures the table is filtered correctly if the hash is present when the page is loaded.
