### PR TITLE
give more space to descriptions

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,7 +31,18 @@ $(function() {
             aaData: data.packages,
             fnInitComplete: function() {
                 $spinner.remove();
-            }
+            },
+            bAutoWidth: false,
+            aoColumns: [
+              {sWidth: '80px'},
+              {sWidth: '400px'},
+              {sWidth: '60px'},
+              {sWidth: '35px'},
+              {sWidth: '25px'},
+              {sWidth: '40px'},
+              {sWidth: '20px'},
+              {sWidth: '20px'}
+            ]
         });
 
         date = new Date(data.end);

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@ th {
     -webkit-border-radius: 10px;
     -moz-border-radius: 10px;
     border-radius: 10px;
-    width: 900px;
+    min-width: 1000px;
     margin: 10px auto;
 }
 


### PR DESCRIPTION
I alwaly search on this page. But I can hardly read full descriptions.
I specified each block's width according to the second anwser:
http://stackoverflow.com/questions/604933/jquery-datatables-table-width-problem
My screen is 1280*768 , seems fine on Chrome, Firefox on Ubuntu, fine on IE.
Here's the demo: http://jiyinyiyong.github.com/nipster/
